### PR TITLE
ユーザー機能周辺のルーティング・仮おきページ修正

### DIFF
--- a/app/assets/stylesheets/brands/show.scss
+++ b/app/assets/stylesheets/brands/show.scss
@@ -1,4 +1,3 @@
 .brands-show {
   padding-top: 52px;
-  background-color: $color-white;
 }

--- a/app/assets/stylesheets/brewages/new.scss
+++ b/app/assets/stylesheets/brewages/new.scss
@@ -1,4 +1,3 @@
 .brewages-new {
   padding-top: 52px;
-  background-color: $color-white;
 }

--- a/app/assets/stylesheets/brewages/show.scss
+++ b/app/assets/stylesheets/brewages/show.scss
@@ -1,4 +1,3 @@
 .brewages-show {
   padding-top: 52px;
-  background-color: $color-white;
 }

--- a/app/assets/stylesheets/users/show.scss
+++ b/app/assets/stylesheets/users/show.scss
@@ -1,3 +1,3 @@
-// Place all the styles related to the users controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
+.users-show {
+  padding-top: 52px;
+}

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/plataformatec/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,60 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up → signup
+  def new
+    super
+  end
+
+  # POST /resource
+  def create
+    super
+  end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,29 @@
+class Users::SessionsController < Devise::SessionsController
+  # before_action :redirect_root, only: :logout
+  
+  # GET /resource/sign_in
+  def newÓ
+    super
+  end
+
+  # POST /resource/sign_in
+  def create
+    super
+  end
+
+  def logout
+
+  end
+
+  # DELETE /resource/sign_out
+  def destroy
+    super
+  end
+
+  private
+
+  def redirect_root
+    redirect_to root_path unless user_signed_in?
+  end
+
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
   def show
+    @user = User.find(params[:id])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,10 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
   has_many :brewages
 
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
   validates :nickname, presence: true
 end

--- a/app/views/shared/_no_login_user_header.html.haml
+++ b/app/views/shared/_no_login_user_header.html.haml
@@ -2,6 +2,6 @@
   .header__right__user-menu    
     %ul
       %li
-        = link_to "新規登録", new_user_registration_path
+        = link_to "新規登録", signup_path
       %li
-        = link_to "ログイン", new_user_session_path
+        = link_to "ログイン", login_path

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,6 +1,9 @@
 = render "shared/header"
-プロフィール
--# コメント数
--# Like
+.users-show
+  #{@user.nickname} さんのマイページ
+  -# コメント数
+  -# Like
+.users-show__logout
+  = link_to "ログアウト", destroy_user_session_path, method: :delete
 = render 'shared/footer'
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -4,6 +4,6 @@
   -# コメント数
   -# Like
 .users-show__logout
-  = link_to "ログアウト", destroy_user_session_path, method: :delete
+  = link_to "ログアウト", logout_path, method: :delete
 = render 'shared/footer'
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,7 +8,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '135c376185ac12ea7d6e6253dd88c3f7276b64e09e5d8b3d8eb3dbb62e3bc5fc7f49a31387afe65352312b2036e48fd23171e715a2523c6743068d47f2b44ec5'
+  # config.secret_key = 'bb5cb3b522ada785c62bc649f51d02fd58f46a2bd5587a33fbca57ccbf529b059657e6cff5d7a6e91b70dc7a22e325b4e533aa67f4f9da7b9ff5c4dad44a2888'
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
@@ -114,7 +114,7 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 11
 
   # Set up a pepper to generate the hashed password.
-  # config.pepper = '92fac39d43f04f4e099128a35f72e47cdbf3a07dc87a3fd6e2f4344d2578de15a63a7dc4396e1206a801734698557a25abdc8e70c3886bc312b1abc6f16e3769'
+  # config.pepper = 'a46998235b761912db1dfa44007db2e4d44ee57b99ada17a4f8fc8f5b5df35a0b21d83216b02678509b75d1e8d3d007f5c9b5ce74bfe5d092df4e8a4a9ccff87'
 
   # Send a notification to the original email when the user's email is changed.
   # config.send_email_changed_notification = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,18 +1,15 @@
 Rails.application.routes.draw do
-  devise_for :users
-  # ,
-  #  controllers: {
-  #   registrations: 'users/registrations',
-  #   sessions: 'users/sessions'
-  # }
+  devise_for :users, controllers: {
+    registrations: 'users/registrations',
+    sessions: 'users/sessions'
+  }
 
-  # devise_scope :user do
-  #   get 'login',      to: 'users/sessions#new'
-  #   post 'login',     to: 'users/sessions#create'
-  #   get 'logout',     to: 'users/sessions#logout'
-  #   delete 'logout',  to: 'users/sessions#destroy'
-  #   get 'signup',     to: 'users/registrations#signup'
-  # end
+  devise_scope :user do
+    get     'login',   to: 'users/sessions#new'
+    post    'login',   to: 'users/sessions#create'
+    get     'signup',  to: 'users/registrations#new'
+  end
+
   resources :users, only: :show
   
   resources :brands, only: [:index, :show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   devise_scope :user do
     get     'login',   to: 'users/sessions#new'
     post    'login',   to: 'users/sessions#create'
+    delete  'logout',   to: 'users/sessions#destroy'
     get     'signup',  to: 'users/registrations#new'
   end
 

--- a/db/migrate/20191228051609_add_remember_created_at_to_users.rb
+++ b/db/migrate/20191228051609_add_remember_created_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberCreatedAtToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :remember_created_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_27_013124) do
+ActiveRecord::Schema.define(version: 2019_12_28_051609) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture_id"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2019_12_27_013124) do
     t.datetime "reset_password_sent_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "remember_created_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# What
- usersテーブルに`remember_created_at`を追加。
- users controllerを作成。
- 主要機能のpath（login，logout，signup）を置き換え。
- 仮おきページを修正。bg指定なし、pathの簡略化など。

# Why
- ログアウトができない症状を修正するため
- devise関連の手入れをしやすくするため
